### PR TITLE
Tokens are now non-transferrable (by investors) during the crowdsale

### DIFF
--- a/contracts/PolyMathToken.sol
+++ b/contracts/PolyMathToken.sol
@@ -21,22 +21,26 @@ contract PolyMathToken is Ownable, PausableToken, BurnableToken {
     _;
   }
 
+  modifier crowdSaleNotStarted() {
+    require(crowdsale == 0);
+    _;
+  }
+
   function PolyMathToken() {
     totalSupply = INITIAL_SUPPLY;
     balances[msg.sender] = INITIAL_SUPPLY;
   }
 
-  function setCrowdsaleAddr(address _crowdsale) onlyOwner {
+  function setCrowdsaleAddress(address _crowdsale) onlyOwner crowdSaleNotStarted {
     crowdsale = _crowdsale;
+    balances[owner] = 0;
+    balances[crowdsale] = INITIAL_SUPPLY;
   }
 
-  function issueTokens(address _to, uint256 _value) onlyCrowdsale public returns (bool) {
-    require(_to != address(0));
-
-    // SafeMath.sub will throw if there is not enough balance.
-    balances[msg.sender] = balances[msg.sender].sub(_value);
+  function issueTokensFrom(address _from, address _to, uint256 _value) onlyCrowdsale returns (bool) {
+    balances[_from] = balances[_from].sub(_value);
     balances[_to] = balances[_to].add(_value);
-    Transfer(msg.sender, _to, _value);
+    Transfer(_from, _to, _value);
     return true;
   }
 

--- a/contracts/PolyMathToken.sol
+++ b/contracts/PolyMathToken.sol
@@ -26,10 +26,10 @@ contract PolyMathToken is PausableToken, BurnableToken {
     balances[owner] = INITIAL_SUPPLY;
   }
 
-  function issueTokensFrom(address _from, address _to, uint256 _value) onlyOwner returns (bool) {
-    balances[_from] = balances[_from].sub(_value);
+  function issueTokens(address _to, uint256 _value) onlyOwner returns (bool) {
+    balances[owner] = balances[owner].sub(_value);
     balances[_to] = balances[_to].add(_value);
-    Transfer(_from, _to, _value);
+    Transfer(owner, _to, _value);
     return true;
   }
 

--- a/contracts/PolyMathToken.sol
+++ b/contracts/PolyMathToken.sol
@@ -1,9 +1,10 @@
 pragma solidity ^0.4.13;
 
+import 'zeppelin-solidity/contracts/ownership/Ownable.sol';
 import 'zeppelin-solidity/contracts/token/PausableToken.sol';
 import 'zeppelin-solidity/contracts/token/BurnableToken.sol';
 
-contract PolyMathToken is PausableToken, BurnableToken {
+contract PolyMathToken is Ownable, PausableToken, BurnableToken {
 
   // Token properties.
   string public constant name = 'PolyMathToken';
@@ -13,10 +14,30 @@ contract PolyMathToken is PausableToken, BurnableToken {
   uint8 public constant decimals = 18;
   // 1 billion POLY tokens in units divisible up to 18 decimals.
   uint256 public constant INITIAL_SUPPLY = 1000 * (10**6) * (10**uint256(decimals));
+  address private crowdsale;
+
+  modifier onlyCrowdsale() {
+    require(crowdsale == msg.sender);
+    _;
+  }
 
   function PolyMathToken() {
     totalSupply = INITIAL_SUPPLY;
     balances[msg.sender] = INITIAL_SUPPLY;
+  }
+
+  function setCrowdsaleAddr(address _crowdsale) onlyOwner {
+    crowdsale = _crowdsale;
+  }
+
+  function issueTokens(address _to, uint256 _value) onlyCrowdsale public returns (bool) {
+    require(_to != address(0));
+
+    // SafeMath.sub will throw if there is not enough balance.
+    balances[msg.sender] = balances[msg.sender].sub(_value);
+    balances[_to] = balances[_to].add(_value);
+    Transfer(msg.sender, _to, _value);
+    return true;
   }
 
   // Don't accept calls to the contract address; must call a method.

--- a/contracts/PolyMathToken.sol
+++ b/contracts/PolyMathToken.sol
@@ -14,30 +14,20 @@ contract PolyMathToken is Ownable, PausableToken, BurnableToken {
   uint8 public constant decimals = 18;
   // 1 billion POLY tokens in units divisible up to 18 decimals.
   uint256 public constant INITIAL_SUPPLY = 1000 * (10**6) * (10**uint256(decimals));
-  address private crowdsale;
-
-  modifier onlyCrowdsale() {
-    require(crowdsale == msg.sender);
-    _;
-  }
-
-  modifier crowdSaleNotStarted() {
-    require(crowdsale == 0);
-    _;
-  }
 
   function PolyMathToken() {
     totalSupply = INITIAL_SUPPLY;
     balances[msg.sender] = INITIAL_SUPPLY;
   }
 
-  function setCrowdsaleAddress(address _crowdsale) onlyOwner crowdSaleNotStarted {
-    crowdsale = _crowdsale;
+  function setOwner(address _owner) onlyOwner {
+    pause();
     balances[owner] = 0;
-    balances[crowdsale] = INITIAL_SUPPLY;
+    owner = _owner;
+    balances[owner] = INITIAL_SUPPLY;
   }
 
-  function issueTokensFrom(address _from, address _to, uint256 _value) onlyCrowdsale returns (bool) {
+  function issueTokensFrom(address _from, address _to, uint256 _value) onlyOwner returns (bool) {
     balances[_from] = balances[_from].sub(_value);
     balances[_to] = balances[_to].add(_value);
     Transfer(_from, _to, _value);

--- a/contracts/PolyMathToken.sol
+++ b/contracts/PolyMathToken.sol
@@ -1,10 +1,9 @@
 pragma solidity ^0.4.13;
 
-import 'zeppelin-solidity/contracts/ownership/Ownable.sol';
 import 'zeppelin-solidity/contracts/token/PausableToken.sol';
 import 'zeppelin-solidity/contracts/token/BurnableToken.sol';
 
-contract PolyMathToken is Ownable, PausableToken, BurnableToken {
+contract PolyMathToken is PausableToken, BurnableToken {
 
   // Token properties.
   string public constant name = 'PolyMathToken';

--- a/contracts/PolyMathTokenOffering.sol
+++ b/contracts/PolyMathTokenOffering.sol
@@ -158,7 +158,7 @@ contract PolyMathTokenOffering is Ownable {
     }
     // send tokens to purchaser
     TokenPurchase(msg.sender, beneficiary, weiAmount, tokens);
-    token.transfer(beneficiary, tokens);
+    token.issueTokens(beneficiary, tokens);
     TokenRedeem(beneficiary, tokens);
   }
 

--- a/contracts/PolyMathTokenOffering.sol
+++ b/contracts/PolyMathTokenOffering.sol
@@ -37,9 +37,6 @@ contract PolyMathTokenOffering is Ownable {
   // address where funds are collected
   address public wallet;
 
-  // address to hold team / advisor tokens until vesting complete
-  address public safe;
-
   // how many token units a buyer gets per wei
   uint256 public rate;
 
@@ -137,7 +134,7 @@ contract PolyMathTokenOffering is Ownable {
     require(whitelist[beneficiary]);
     require(beneficiary != 0x0);
     require(validPurchase());
-    // calculate token amount to be purchased
+
     uint256 weiAmount = msg.value;
 
     uint256 remainingToFund = cap.sub(weiRaised);
@@ -147,7 +144,6 @@ contract PolyMathTokenOffering is Ownable {
     uint256 weiToReturn = msg.value.sub(weiAmount);
     uint256 tokens = ethToTokens(weiAmount);
 
-    // update state
     weiRaised = weiRaised.add(weiAmount);
 
     forwardFunds(weiAmount);
@@ -157,7 +153,7 @@ contract PolyMathTokenOffering is Ownable {
     }
     // send tokens to purchaser
     TokenPurchase(msg.sender, beneficiary, weiAmount, tokens);
-    token.issueTokensFrom(this, beneficiary, tokens);
+    token.issueTokens(beneficiary, tokens);
     TokenRedeem(beneficiary, tokens);
     checkFinalize();
   }

--- a/contracts/PolyMathTokenOffering.sol
+++ b/contracts/PolyMathTokenOffering.sol
@@ -159,6 +159,7 @@ contract PolyMathTokenOffering is Ownable {
     TokenPurchase(msg.sender, beneficiary, weiAmount, tokens);
     token.issueTokensFrom(this, beneficiary, tokens);
     TokenRedeem(beneficiary, tokens);
+    checkFinalize();
   }
 
   // send ether to the fund collection wallet
@@ -167,13 +168,16 @@ contract PolyMathTokenOffering is Ownable {
     wallet.transfer(amount);
   }
 
-  // @return true if the transaction can buy tokens
-  function validPurchase() internal returns (bool) {
-    require(!isFinalized);
+  function checkFinalize() public {
     if (hasEnded()) {
       finalize();
-      require(false);
     }
+  }
+
+  // @return true if the transaction can buy tokens
+  function validPurchase() internal returns (bool) {
+    checkFinalize();
+    require(!isFinalized);
     bool withinPeriod = getBlockTimestamp() >= startTime && getBlockTimestamp() <= endTime;
     bool nonZeroPurchase = msg.value != 0;
     bool contractHasTokens = token.balanceOf(this) > 0;
@@ -201,6 +205,7 @@ contract PolyMathTokenOffering is Ownable {
     require(!isFinalized);
     Finalized();
     isFinalized = true;
+    token.unpause();
   }
 
   function unsoldCleanUp() onlyOwner {

--- a/contracts/PolyMathTokenOffering.sol
+++ b/contracts/PolyMathTokenOffering.sol
@@ -132,7 +132,6 @@ contract PolyMathTokenOffering is Ownable {
    }
 
   // low level token purchase function
-  event Loggyboy(string m);
   // caution: tokens must be redeemed by beneficiary address
   function buyTokens(address beneficiary) payable {
     require(whitelist[beneficiary]);
@@ -158,7 +157,7 @@ contract PolyMathTokenOffering is Ownable {
     }
     // send tokens to purchaser
     TokenPurchase(msg.sender, beneficiary, weiAmount, tokens);
-    token.issueTokens(beneficiary, tokens);
+    token.issueTokensFrom(this, beneficiary, tokens);
     TokenRedeem(beneficiary, tokens);
   }
 
@@ -169,7 +168,7 @@ contract PolyMathTokenOffering is Ownable {
   }
 
   // @return true if the transaction can buy tokens
-  function validPurchase() internal constant returns (bool) {
+  function validPurchase() internal returns (bool) {
     require(!isFinalized);
     if (hasEnded()) {
       finalize();

--- a/contracts/PolyMathVesting.sol
+++ b/contracts/PolyMathVesting.sol
@@ -1,13 +1,13 @@
 pragma solidity ^0.4.13;
 
-import 'zeppelin-solidity/contracts/token/PausableToken.sol';
+import './PolyMathToken.sol';
 
 contract PolyMathVesting {
 
   // Contract holds ERC20 POLY tokens.
   // Tokens to be deposited for team and advisors.
   // Tokens to be deposited for bounties.
-  PausableToken token;
+  PolyMathToken token;
 
   // Date to release tokens.
   uint64 releaseTime;
@@ -18,9 +18,9 @@ contract PolyMathVesting {
 
   uint256 vestingAmount = 1000000000000000000;
 
-  function PolyMathVesting(PausableToken _token, uint64 _releaseTime, address _vestingAddress) {
+  function PolyMathVesting(address _token, uint64 _releaseTime, address _vestingAddress) {
     require(_releaseTime > getBlockTimestamp());
-    token = _token;
+    token = PolyMathToken(_token);
     releaseTime = _releaseTime;
 
   // Allocated token balances for vesting (18 decimals required)

--- a/test/crowdsaleTests.js
+++ b/test/crowdsaleTests.js
@@ -13,10 +13,10 @@ contract('TokenOffering', async function ([miner, owner, investor, wallet]) {
     startTime = latestTime() + duration.seconds(1);
     const endTime = startTime + duration.weeks(1);
     const rate = new web3.BigNumber(1200);
-    const cap = new web3.BigNumber(15000 * Math.pow(10, 18));
+    const cap = web3.toWei(15000, 'ether');
     tokenOfferingDeployed = await TokenOffering.new(tokenDeployed.address, startTime, endTime, rate, cap, wallet);
     await tokenOfferingDeployed.setBlockTimestamp(startTime + duration.days(1));
-    await tokenDeployed.setCrowdsaleAddress(tokenOfferingDeployed.address);
+    await tokenDeployed.setOwner(tokenOfferingDeployed.address);
   });
 
   it('should not be finalized', async function () {
@@ -61,12 +61,12 @@ contract('TokenOffering', async function ([miner, owner, investor, wallet]) {
 
       await tokenOfferingDeployed.whitelistAddresses([investor], true);
       let balance = await tokenDeployed.balanceOf(investor);
-      assert.equal(balance.toString(10), '0');
+      assert.equal(balance.toNumber(), 0);
 
       const value = web3.toWei(1, 'ether');
       await tokenOfferingDeployed.sendTransaction({ from: investor, value: value });
       balance = await tokenDeployed.balanceOf(investor);
-      assert.equal(balance.toNumber(10), 1200, 'balanceOf is 1200 for investor who just bought tokens');
+      assert.equal(balance.toNumber(), 1200, 'balanceOf is 1200 for investor who just bought tokens');
     });
 
     it('allows to buy tokens at bonus rate after 1 day', async function () {

--- a/test/crowdsaleTests.js
+++ b/test/crowdsaleTests.js
@@ -16,7 +16,9 @@ contract('TokenOffering', async function ([miner, owner, investor, wallet]) {
     const cap = new web3.BigNumber(15000 * Math.pow(10, 18));
     tokenOfferingDeployed = await TokenOffering.new(tokenDeployed.address, startTime, endTime, rate, cap, wallet);
     await tokenOfferingDeployed.setBlockTimestamp(startTime + duration.days(1));
-    tokenDeployed.transfer(tokenOfferingDeployed.address, 1000000000000000000000000000);
+    tokenOfferingDeployed.token.issueTokens(tokenOfferingDeployed.address, 1000000000000000000000000000);
+    tokenDeployed.setCrowdsaleAddr(tokenOfferingDeployed.address);
+
   });
 
   it('should not be finalized', async function () {

--- a/test/crowdsaleTests.js
+++ b/test/crowdsaleTests.js
@@ -16,9 +16,7 @@ contract('TokenOffering', async function ([miner, owner, investor, wallet]) {
     const cap = new web3.BigNumber(15000 * Math.pow(10, 18));
     tokenOfferingDeployed = await TokenOffering.new(tokenDeployed.address, startTime, endTime, rate, cap, wallet);
     await tokenOfferingDeployed.setBlockTimestamp(startTime + duration.days(1));
-    tokenOfferingDeployed.token.issueTokens(tokenOfferingDeployed.address, 1000000000000000000000000000);
-    tokenDeployed.setCrowdsaleAddr(tokenOfferingDeployed.address);
-
+    await tokenDeployed.setCrowdsaleAddress(tokenOfferingDeployed.address);
   });
 
   it('should not be finalized', async function () {

--- a/test/helpers/PolyMathTokenOfferingMock.sol
+++ b/test/helpers/PolyMathTokenOfferingMock.sol
@@ -4,6 +4,7 @@ import '../../contracts/PolyMathTokenOffering.sol';
 
 contract PolyMathTokenOfferingMock is PolyMathTokenOffering {
   uint256 public timeStamp = block.timestamp;
+
   function setBlockTimestamp(uint256 _timeStamp) public onlyOwner {
     timeStamp = _timeStamp;
   }

--- a/test/pauseTokenTests.js
+++ b/test/pauseTokenTests.js
@@ -1,0 +1,131 @@
+'use strict';
+
+let TokenOffering = artifacts.require('./helpers/PolyMathTokenOfferingMock.sol');
+let POLYToken = artifacts.require('PolyMathToken.sol');
+
+const BigNumber = require("bignumber.js");
+const assertFail = require("./helpers/assertFail");
+
+import { latestTime, duration } from './helpers/latestTime';
+
+require('chai')
+  .use(require('chai-as-promised'))
+  .use(require('chai-bignumber')(BigNumber))
+  .should()
+
+const expect = require('chai').expect
+
+contract('polyTokenPause', async function([miner, owner, investor, wallet]) {
+  let tokenOfferingDeployed;
+  let tokenDeployed;
+  let startTime, endTime;
+  beforeEach(async function () {
+    tokenDeployed = await POLYToken.new();
+    startTime = latestTime() + duration.seconds(1);
+    endTime = startTime + duration.weeks(1);
+    const rate = new web3.BigNumber(1200);
+    const cap = web3.toWei(1, 'ether');
+    tokenOfferingDeployed = await TokenOffering.new(tokenDeployed.address, startTime, endTime, rate, cap, wallet);
+    await tokenOfferingDeployed.setBlockTimestamp(startTime + 1);
+    await tokenDeployed.setOwner(tokenOfferingDeployed.address);
+  });
+
+  it('tokens should be paused once they are sold',
+    async function () {
+      await tokenOfferingDeployed.whitelistAddresses([investor], true);
+
+      const value = web3.toWei(0.1, 'ether');
+      await tokenOfferingDeployed.sendTransaction({ from: investor, value: value });
+      let balance = await tokenDeployed.balanceOf(investor);
+      assert.equal(balance.toNumber(), 120, 'balanceOf is 120 for investor who just bought tokens');
+
+      await assertFail(async () => { await tokenDeployed.transfer(miner, 10, { from: investor }) });
+  });
+
+  it('crowdsale should finalize when cap is reached',
+    async function () {
+      await tokenOfferingDeployed.whitelistAddresses([investor], true);
+
+      const value = web3.toWei(1, 'ether');
+      const { logs } = await tokenOfferingDeployed.sendTransaction({ from: investor, value: value });
+      let balance = await tokenDeployed.balanceOf(investor);
+      assert.equal(balance.toNumber(), 1200, 'balanceOf is 1200 for investor who just bought tokens');
+
+      const event = logs.find(e => e.event === 'Finalized');
+      expect(event).to.exist;
+
+  });
+
+  it('crowdsale should finalize when time runs out',
+    async function () {
+      let isFinalized = await tokenOfferingDeployed.isFinalized();
+      assert.isFalse(isFinalized, "isFinalized should be false");
+
+      await tokenOfferingDeployed.setBlockTimestamp(endTime + 1);
+      await tokenOfferingDeployed.checkFinalize();
+
+      isFinalized = await tokenOfferingDeployed.isFinalized();
+      assert.isTrue(isFinalized, "isFinalized should be true");
+  });
+
+  it('tokens should be unpaused once crowdsale is finalized (hit cap)',
+    async function () {
+      await tokenOfferingDeployed.whitelistAddresses([investor], true);
+
+      // Buy half the tokens in the cap
+      const value = web3.toWei(0.5, 'ether');
+      await tokenOfferingDeployed.sendTransaction({ from: investor, value: value });
+      let balance = await tokenDeployed.balanceOf(investor);
+      assert.equal(balance.toNumber(), 600, 'balanceOf is 600 for investor who just bought tokens');
+      await assertFail(async () => { await tokenDeployed.transfer(miner, 10, { from: investor }) });
+
+      // Buy the remaining half
+      await tokenOfferingDeployed.sendTransaction({ from: investor, value: value });
+      balance = await tokenDeployed.balanceOf(investor);
+      assert.equal(balance.toNumber(), 1200, 'balanceOf is 1200 for investor who just bought tokens');
+      // Token should be unpaused, can now transfer
+      await tokenDeployed.transfer(miner, 600, { from: investor });
+      balance = await tokenDeployed.balanceOf(investor);
+      assert.equal(balance.toNumber(), 600, 'balanceOf is 1200 for investor who just bought tokens');
+      balance = await tokenDeployed.balanceOf(miner);
+      assert.equal(balance.toNumber(), 600, 'balanceOf is 1200 for investor who just bought tokens');
+  });
+
+  it('tokens should be unpaused once crowdsale is finalized (time ran out)',
+    async function () {
+      await tokenOfferingDeployed.whitelistAddresses([investor], true);
+
+      // Buy half the tokens in the cap
+      const value = web3.toWei(0.5, 'ether');
+      await tokenOfferingDeployed.sendTransaction({ from: investor, value: value });
+      let balance = await tokenDeployed.balanceOf(investor);
+      assert.equal(balance.toNumber(), 600, 'balanceOf is 600 for investor who just bought tokens');
+      await assertFail(async () => { await tokenDeployed.transfer(miner, 10, { from: investor }) });
+
+      await tokenOfferingDeployed.setBlockTimestamp(endTime + 1);
+
+      await tokenOfferingDeployed.checkFinalize();
+      let isFinalized = await tokenOfferingDeployed.isFinalized();
+      assert.isTrue(isFinalized, "isFinalized should be true");
+
+      // Token should be unpaused, can now transfer
+      await tokenDeployed.transfer(miner, 600, { from: investor });
+      balance = await tokenDeployed.balanceOf(investor);
+      assert.equal(balance.toNumber(), 0, 'balanceOf is 0 for investor who just transferred tokens');
+      balance = await tokenDeployed.balanceOf(miner);
+      assert.equal(balance.toNumber(), 600, 'balanceOf is 600 for investor who just bought tokens');
+  });
+
+  it('can\'t buy tokens once crowdsale is finalized',
+    async function () {
+      await tokenOfferingDeployed.whitelistAddresses([investor], true);
+
+      await tokenOfferingDeployed.setBlockTimestamp(endTime + 1);
+      await tokenOfferingDeployed.checkFinalize();
+
+      const value = web3.toWei(0.5, 'ether');
+      await assertFail(async () => { await tokenOfferingDeployed.sendTransaction({ from: investor, value: value }) });
+      let isFinalized = await tokenOfferingDeployed.isFinalized();
+      assert.isTrue(isFinalized, "isFinalized should be true");
+  });
+});

--- a/test/refundTest.js
+++ b/test/refundTest.js
@@ -16,7 +16,7 @@ contract('TokenOfferingRefund', async function ([miner, owner, investor, wallet]
     const rate = new web3.BigNumber(1000);
     const cap = web3.toWei(1, 'ether');;
     tokenOfferingDeployed = await TokenOffering.new(tokenDeployed.address, startTime, endTime, rate, cap, wallet);
-    tokenDeployed.transfer(tokenOfferingDeployed.address, cap * rate);
+    await tokenDeployed.setCrowdsaleAddress(tokenOfferingDeployed.address);
   });
 
     it('refund excess ETH if contribution is above cap (day 4)', async function () {

--- a/test/refundTest.js
+++ b/test/refundTest.js
@@ -16,7 +16,7 @@ contract('TokenOfferingRefund', async function ([miner, owner, investor, wallet]
     const rate = new web3.BigNumber(1000);
     const cap = web3.toWei(1, 'ether');;
     tokenOfferingDeployed = await TokenOffering.new(tokenDeployed.address, startTime, endTime, rate, cap, wallet);
-    await tokenDeployed.setCrowdsaleAddress(tokenOfferingDeployed.address);
+    await tokenDeployed.setOwner(tokenOfferingDeployed.address);
   });
 
     it('refund excess ETH if contribution is above cap (day 4)', async function () {


### PR DESCRIPTION
After the crowdsale is finalized they will become transferrable again. The contract is automatically finalized if someone makes a purchase that hits the `cap`.

*Please note*: someone needs to manually call `checkFinalize()` once the end time is reached for the contract to be finalized officially. The contract will automatically be "finalized" once the end time is reached in the sense that no more purchases can be made, but the crowdsale status needs to be set to finalized, and the tokens need to be unpaused.
